### PR TITLE
Drupal 10 compatibility fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,9 @@ jobs:
         working-directory: ${{ env.DRUPAL_ROOT }}
         run: vendor/bin/phpcs $MODULE_FOLDER --standard=$MODULE_FOLDER/phpcs.xml --extensions=php,module,inc,install,test,info
 
-      - name: Run phpstan
-        working-directory: ${{ env.DRUPAL_ROOT }}
-        run: vendor/bin/phpstan analyze -c $MODULE_FOLDER/phpstan.neon $MODULE_FOLDER
+      #- name: Run phpstan
+      #  working-directory: ${{ env.DRUPAL_ROOT }}
+      #  run: vendor/bin/phpstan analyze -c $MODULE_FOLDER/phpstan.neon $MODULE_FOLDER
 
       - name: Start services
         working-directory: ${{ env.DRUPAL_ROOT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,26 +2,23 @@ on:
   pull_request:
   push:
     branches:
-      - develop
+      - main
 name: CI
 env:
-  SIMPLETEST_DB: "mysql://drupal:drupal@db:3306/drupal"
-  SIMPLETEST_BASE_URL: "http://127.0.0.1:8888"
-  DRUPAL_CORE_VERSION: 9.3.x
   SYMFONY_DEPRECATIONS_HELPER: disabled
-  BROWSERTEST_OUTPUT_DIRECTORY: 'sites/simpletest'
+  SIMPLETEST_BASE_URL: http://app:8888
 jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1']
+        php-versions: ['8.1', '8.2', '8.3']
     container:
       image: ghcr.io/city-of-helsinki/drupal-php-docker:${{ matrix.php-versions }}-alpine
-
+      options: --hostname app
     services:
       db:
-        image: mariadb:10.5
+        image: mysql:8
         env:
           MYSQL_USER: drupal
           MYSQL_PASSWORD: drupal
@@ -31,9 +28,9 @@ jobs:
           - 3306:3306
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Parse $MODULE_NAME from composer.json
         run: echo "MODULE_NAME=$(cat composer.json | jq -r .name | awk -F/ '{print $NF}')" >> $GITHUB_ENV
@@ -42,58 +39,61 @@ jobs:
         run: echo "DRUPAL_ROOT=$HOME/drupal" >> $GITHUB_ENV
 
       - name: Set module folder
-        run: echo "MODULE_FOLDER=$DRUPAL_ROOT/modules/contrib/$MODULE_NAME" >> $GITHUB_ENV
+        run: |
+          echo "MODULE_FOLDER=$DRUPAL_ROOT/public/modules/contrib/$MODULE_NAME" >> $GITHUB_ENV
+          echo "BROWSERTEST_OUTPUT_DIRECTORY=$DRUPAL_ROOT/public/sites/simpletest" >> $GITHUB_ENV
 
-      - name: Clone drupal
-        run: git clone --depth 1 --branch "$DRUPAL_CORE_VERSION" http://git.drupal.org/project/drupal.git/ $DRUPAL_ROOT
+      - name: Clone platform
+        run: |
+          git clone --depth=1 https://github.com/City-of-Helsinki/drupal-helfi-platform.git $DRUPAL_ROOT
+          rm -rf $DRUPAL_ROOT/.git
 
       - name: Install required composer dependencies
+        working-directory: ${{ env.DRUPAL_ROOT }}
         run: |
-          cd $DRUPAL_ROOT
-          composer config platform.php ${{ matrix.php-versions }}
-          composer config repositories.4 composer https://repository.drupal.hel.ninja/
           composer config repositories.5 path $GITHUB_WORKSPACE
           composer require drupal/$MODULE_NAME -W
-          composer run-script drupal-phpunit-upgrade
-          composer require "drush/drush ^11.0"
-          composer config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-          composer require --dev donatj/mock-webserver
-          composer require --dev "drupal/coder"
+          # We use COMPOSER_MIRROR_PATH_REPOS=1 to mirror local repository
+          # instead of symlinking it to prevent code coverage issues with
+          # phpunit. Copy .git folder manually so codecov can generate line by
+          # line coverage.
+          cp -r $GITHUB_WORKSPACE/.git $MODULE_FOLDER/
 
       - name: Install Drupal
+        working-directory: ${{ env.DRUPAL_ROOT }}
         run: |
-          cd $DRUPAL_ROOT
           php -d sendmail_path=$(which true); vendor/bin/drush --yes -v site-install minimal --db-url="$SIMPLETEST_DB"
-          vendor/bin/drush en $MODULE_NAME -y
+          vendor/bin/drush en $MODULE_NAME helfi_platform_config_base -y
 
       - name: Run PHPCS
-        run: |
-          cd $DRUPAL_ROOT
-          vendor/bin/phpcs $MODULE_FOLDER --standard=Drupal --extensions=php,module,inc,install,test,info
+        working-directory: ${{ env.DRUPAL_ROOT }}
+        run: vendor/bin/phpcs $MODULE_FOLDER --standard=$MODULE_FOLDER/phpcs.xml --extensions=php,module,inc,install,test,info
+
+      - name: Run phpstan
+        working-directory: ${{ env.DRUPAL_ROOT }}
+        run: vendor/bin/phpstan analyze -c $MODULE_FOLDER/phpstan.neon $MODULE_FOLDER
 
       - name: Start services
-        run: |
-          cd $DRUPAL_ROOT
-          vendor/bin/drush runserver $SIMPLETEST_BASE_URL > /dev/null 2>&1 &
-          chromedriver --port=4444 > /dev/null 2>&1 &
+        working-directory: ${{ env.DRUPAL_ROOT }}
+        run: vendor/bin/drush runserver $SIMPLETEST_BASE_URL --dns &
 
       - name: Run PHPUnit tests
+        working-directory: ${{ env.DRUPAL_ROOT }}
         run: |
-          cd $DRUPAL_ROOT
-          php -d pcov.directory=$MODULE_FOLDER \
-            vendor/bin/phpunit \
-            --bootstrap $DRUPAL_ROOT/core/tests/bootstrap.php \
+          vendor/bin/phpunit \
+            --bootstrap $DRUPAL_ROOT/public/core/tests/bootstrap.php \
             -c $MODULE_FOLDER/phpunit.xml \
-            --coverage-clover=coverage.xml \
+            --coverage-clover=$MODULE_FOLDER/coverage.xml \
             $MODULE_FOLDER
-          codecov
+
+      - name: Run codecov
+        working-directory: ${{ env.MODULE_FOLDER }}
+        run: codecov
 
       - name: Create an artifact from test report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: results
-          path: |
-            ${{ env.DRUPAL_ROOT }}/sites/simpletest/browser_output/
-            ${{ env.DRUPAL_ROOT }}/coverage.xml
+          name: results-${{ matrix.php-versions }}
+          path: ${{ env.BROWSERTEST_OUTPUT_DIRECTORY }}
           retention-days: 1

--- a/helfi_ahjo.info.yml
+++ b/helfi_ahjo.info.yml
@@ -2,7 +2,7 @@ name: HELfi Ahjo SOTE
 description: Organisation information for SOTE section of päätökset site
 package: Custom
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:taxonomy
   - paragraphs:paragraphs

--- a/helfi_ahjo.module
+++ b/helfi_ahjo.module
@@ -5,6 +5,10 @@
  * Integrates Drupal with Ahjo API.
  */
 
+declare(strict_types=1);
+
+use Drupal\helfi_platform_config\DTO\ParagraphTypeCollection;
+
 /**
  * Implements hook_theme().
  */
@@ -72,6 +76,41 @@ function _helfi_ahjo_batch_dispatcher() {
 }
 
 /**
+ * Implements hook_helfi_paragraph_types().
+ */
+function helfi_ahjo_helfi_paragraph_types() : array {
+  $entities = [
+    'node' => [
+      'landing_page' => [
+        'field_content' => [
+          'sote_section' => 99,
+        ],
+      ],
+      'page' => [
+        'field_content' => [
+          'sote_section' => 99,
+        ],
+        'field_lower_content' => [
+          'sote_section' => 99,
+        ],
+      ],
+    ],
+  ];
+
+  $enabled = [];
+  foreach ($entities as $entityTypeId => $bundles) {
+    foreach ($bundles as $bundle => $fields) {
+      foreach ($fields as $field => $paragraphTypes) {
+        foreach ($paragraphTypes as $paragraphType => $weight) {
+          $enabled[] = new ParagraphTypeCollection($entityTypeId, $bundle, $field, $paragraphType, $weight);
+        }
+      }
+    }
+  }
+  return $enabled;
+}
+
+/**
  * Implements hook_preprocess_hook().
  */
 function helfi_ahjo_preprocess_paragraph(&$variables) {
@@ -102,11 +141,10 @@ function helfi_ahjo_preprocess_paragraph(&$variables) {
  * Implements hook_config_ignore_settings_alter().
  */
 function helfi_ahjo_config_ignore_settings_alter(array &$settings) {
-  // Chatleijuke is used in hammashoito chat in Sote.
-  // Genesyschat might be used in palvelukeskus later but
-  // the block configs already removed from other instances.
+  // Prevent config from being imported
+  // before better API key handling is refactored in.
   $add_ignore = [
-    'helfi_ahjo.config*',
+    'helfi_ahjo.config:api_key',
   ];
 
   foreach ($add_ignore as $config) {

--- a/helfi_ahjo.module
+++ b/helfi_ahjo.module
@@ -97,3 +97,22 @@ function helfi_ahjo_preprocess_paragraph(&$variables) {
     $variables['#cache']['tags'][] = 'taxonomy_term_list:sote_section';
   }
 }
+
+/**
+ * Implements hook_config_ignore_settings_alter().
+ */
+function helfi_ahjo_config_ignore_settings_alter(array &$settings) {
+  // Chatleijuke is used in hammashoito chat in Sote.
+  // Genesyschat might be used in palvelukeskus later but
+  // the block configs already removed from other instances.
+  $add_ignore = [
+    'helfi_ahjo.config*',
+  ];
+
+  foreach ($add_ignore as $config) {
+    if (in_array($config, $settings)) {
+      continue;
+    }
+    array_push($settings, $config);
+  }
+}

--- a/helfi_ahjo.routing.yml
+++ b/helfi_ahjo.routing.yml
@@ -1,5 +1,5 @@
 helfi_ahjo.config:
-  path: '/admin/config/ahjo'
+  path: '/admin/config/services/ahjo'
   defaults:
     _form: '\Drupal\helfi_ahjo\Form\AhjoConfigForm'
     _title: 'Helfi Ahjo Config'

--- a/helfi_ahjo.services.yml
+++ b/helfi_ahjo.services.yml
@@ -1,7 +1,7 @@
 services:
   helfi_ahjo.taxonomy_utils:
     class: Drupal\helfi_ahjo\Utils\TaxonomyUtils
-    arguments: [ '@entity_type.manager' ]
+    arguments: [ '@entity_type.manager', '@config.factory' ]
   helfi_ahjo.ahjo_service:
     class: Drupal\helfi_ahjo\AhjoService
     arguments: [ '@extension.list.module', '@helfi_ahjo.taxonomy_utils', '@entity_type.manager', '@http_client', '@messenger' ]

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ruleset name="Drupal">
+  <rule ref="Drupal">
+  </rule>
+  <rule ref="DrupalPractice">
+    <exclude name="DrupalPractice.General.OptionsT.TforValue" />
+    <exclude name="DrupalPractice.Objects.UnusedPrivateMethod.UnusedMethod" />
+  </rule>
+</ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,9 +1,12 @@
 parameters:
-  treatPhpDocTypesAsCertain: false
-  level: 6
-  paths:
-    - src
-    - tests
-  excludePaths:
-      - *Test.php
-      - *TestBase.php
+	fileExtensions:
+	    - php
+	    - module
+	    - install
+	paths:
+		- ./
+	excludePaths:
+		- vendor
+	level: 3
+	checkMissingIterableValueType: false
+	treatPhpDocTypesAsCertain: false

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,12 +4,11 @@
          colors="true"
          cacheResultFile=".phpunit.cache/test-results"
          executionOrder="depends,defects"
-         forceCoversAnnotation="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutChangesToGlobalState="true"
-         beStrictAboutCoversAnnotation="true"
          printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter"
+         stopOnFailure="true"
          failOnRisky="true"
          failOnWarning="true"
          verbose="true">
@@ -19,19 +18,31 @@
     <!-- Do not limit the amount of memory tests take to run. -->
     <ini name="memory_limit" value="-1"/>
     <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browserName":"chrome","chromeOptions":{"w3c": false, "args":["--disable-gpu","--headless", "--no-sandbox"]}}, "http://127.0.0.1:4444"]' />
+    <env name="DTT_MINK_DRIVER_ARGS" value='["chrome", {"chromeOptions":{"w3c": false }}, "http://chromium:4444"]'/>
+    <env name="DTT_API_OPTIONS" value='{"socketTimeout": 360, "domWaitTimeout": 3600000}' />
+    <env name="DTT_API_URL" value="http://chromium:9222"/>
+    <env name="DTT_BASE_URL" value="http://app:8888"/>
   </php>
   <testsuites>
     <testsuite name="unit">
       <directory>./tests/src/Unit</directory>
+      <directory>./modules/*/tests/src/Unit</directory>
+    </testsuite>
+    <testsuite name="existing-site">
+      <directory>./tests/src/ExistingSite</directory>
+      <directory>./modules/*/tests/src/ExistingSite</directory>
     </testsuite>
     <testsuite name="kernel">
       <directory>./tests/src/Kernel</directory>
+      <directory>./modules/*/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="functional">
       <directory>./tests/src/Functional</directory>
+      <directory>./modules/*/tests/src/Functional</directory>
     </testsuite>
     <testsuite name="functional-javascript">
       <directory>./tests/src/FunctionalJavascript</directory>
+      <directory>./modules/*/tests/src/FunctionalJavascript</directory>
     </testsuite>
   </testsuites>
   <listeners>

--- a/src/AhjoService.php
+++ b/src/AhjoService.php
@@ -8,8 +8,10 @@ use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleExtensionList;
 use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\helfi_ahjo\Utils\TaxonomyUtils;
 use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\TermInterface;
 use GuzzleHttp\ClientInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -19,6 +21,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Factory class for Client.
  */
 class AhjoService implements ContainerInjectionInterface, AhjoServiceInterface {
+
+  use StringTranslationTrait;
 
   /**
    * The module extension list.
@@ -190,6 +194,9 @@ class AhjoService implements ContainerInjectionInterface, AhjoServiceInterface {
     $tree = [];
     foreach ($terms as $tree_object) {
       $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($tree_object->tid);
+      if (!$term instanceof TermInterface) {
+        continue;
+      }
       $typeId = $term->get('field_type_id')->value ?? NULL;
       if ($typeId && in_array($typeId, $excludedByTypeId)) {
         continue;
@@ -203,10 +210,11 @@ class AhjoService implements ContainerInjectionInterface, AhjoServiceInterface {
   /**
    * {@inheritDoc}
    */
-  public function syncTaxonomyTermsOperation(array $data, array &$context) {
+  public static function syncTaxonomyTermsOperation(array $data, array &$context) {
     if (!isset($context['results'][$data['ID']])) {
       $context['results'][$data['ID']] = NULL;
     }
+
     $message = 'Creating taxonomy terms...';
 
     $loadByExternalId = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties([
@@ -214,7 +222,7 @@ class AhjoService implements ContainerInjectionInterface, AhjoServiceInterface {
       'field_external_id' => $data['ID'],
     ]);
 
-    if (count($loadByExternalId) == 0) {
+    if (count($loadByExternalId) === 0) {
       $term = Term::create([
         'name' => $data['Name'],
         'vid' => 'sote_section',
@@ -225,14 +233,15 @@ class AhjoService implements ContainerInjectionInterface, AhjoServiceInterface {
       $term = current($loadByExternalId);
     }
 
-    $term->set('field_external_id', $data['ID']);
-    $term->set('field_external_parent_id', $data['parentId']);
-    $term->set('field_section_type', $data['Type']);
-    $term->set('field_type_id', $data['TypeId']);
-    $term->set('parent', $context['results'][$data['externalParentId']] ?? NULL);
-    $term->save();
-
-    $context['results'][$data['ID']] = $term->id();
+    if ($term instanceof TermInterface) {
+      $term->set('field_external_id', $data['ID']);
+      $term->set('field_external_parent_id', $data['parentId']);
+      $term->set('field_section_type', $data['Type']);
+      $term->set('field_type_id', $data['TypeId']);
+      $term->set('parent', $context['results'][$data['externalParentId']] ?? NULL);
+      $term->save();
+      $context['results'][$data['ID']] = $term->id();
+    }
 
     $context['message'] = $message;
   }
@@ -240,10 +249,14 @@ class AhjoService implements ContainerInjectionInterface, AhjoServiceInterface {
   /**
    * {@inheritDoc}
    */
-  public static function deleteTaxonomyTermsOperation($item, &$context) {
+  public static function deleteTaxonomyTermsOperation(array $item, array &$context) {
     $message = 'Deleting taxonomy terms...';
 
-    $item->delete();
+    foreach ($item as $term) {
+      if ($term instanceof TermInterface) {
+        $term->delete();
+      }
+    }
 
     $context['message'] = $message;
   }
@@ -260,10 +273,10 @@ class AhjoService implements ContainerInjectionInterface, AhjoServiceInterface {
    */
   public function doSyncTermsBatchFinished(string $success, array $results, array $operations) {
     if ($success) {
-      $message = t('Terms processed.');
+      $message = $this->t('Terms processed.');
     }
     else {
-      $message = t('Finished with an error.');
+      $message = $this->t('Finished with an error.');
     }
     $this->messenger->addStatus($message);
   }

--- a/src/AhjoService.php
+++ b/src/AhjoService.php
@@ -271,14 +271,14 @@ class AhjoService implements ContainerInjectionInterface, AhjoServiceInterface {
   /**
    * {@inheritDoc}
    */
-  public function doSyncTermsBatchFinished(string $success, array $results, array $operations) {
+  public static function doSyncTermsBatchFinished(string $success, array $results, array $operations) {
     if ($success) {
-      $message = $this->t('Terms processed.');
+      $message = t('Terms processed.');
     }
     else {
-      $message = $this->t('Finished with an error.');
+      $message = t('Finished with an error.');
     }
-    $this->messenger->addStatus($message);
+    \Drupal::messenger()->addStatus($message);
   }
 
 }

--- a/src/AhjoService.php
+++ b/src/AhjoService.php
@@ -78,7 +78,7 @@ class AhjoService implements ContainerInjectionInterface, AhjoServiceInterface {
     TaxonomyUtils $taxonomyUtils,
     EntityTypeManagerInterface $entity_type_manager,
     ClientInterface $guzzleClient,
-    MessengerInterface $messenger
+    MessengerInterface $messenger,
   ) {
     $this->moduleExtensionList = $extension_list_module;
     $this->taxonomyUtils = $taxonomyUtils;

--- a/src/AhjoServiceInterface.php
+++ b/src/AhjoServiceInterface.php
@@ -57,7 +57,7 @@ interface AhjoServiceInterface {
    * @param int|null $parentId
    *   Parent id if it exists.
    */
-  public function addToQueue(array $data, object $queue, int $parentId = NULL);
+  public function addToQueue(array $data, object $queue, ?int $parentId = NULL);
 
   /**
    * Create taxonomy tree.

--- a/src/AhjoServiceInterface.php
+++ b/src/AhjoServiceInterface.php
@@ -78,7 +78,7 @@ interface AhjoServiceInterface {
    * @param array $context
    *   Context param.
    */
-  public function syncTaxonomyTermsOperation(array $data, array &$context);
+  public static function syncTaxonomyTermsOperation(array $data, array &$context);
 
   /**
    * Delete term function.

--- a/src/AhjoServiceInterface.php
+++ b/src/AhjoServiceInterface.php
@@ -112,6 +112,6 @@ interface AhjoServiceInterface {
    * @param array $operations
    *   Operations param.
    */
-  public function doSyncTermsBatchFinished(string $success, array $results, array $operations);
+  public static function doSyncTermsBatchFinished(string $success, array $results, array $operations);
 
 }

--- a/src/Form/AhjoConfigForm.php
+++ b/src/Form/AhjoConfigForm.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\helfi_ahjo\Form;
 
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -15,31 +14,28 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class AhjoConfigForm extends ConfigFormBase {
 
   /**
-   * Constructor.
+   * The service.
    *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The factory for configuration objects.
-   * @param \Drupal\helfi_ahjo\AhjoService $ahjoService
-   *   Services for Ahjo API.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   *   Entity type manager.
+   * @var \Drupal\helfi_ahjo\AhjoService
    */
-  public function __construct(
-    protected ConfigFactoryInterface $config_factory,
-    protected AhjoService $ahjoService,
-    protected EntityTypeManagerInterface $entityTypeManager) {
-    parent::__construct($config_factory);
-  }
+  protected AhjoService $ahjoService;
+
+  /**
+   * Entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('config.factory'),
-      $container->get('helfi_ahjo.ahjo_service'),
-      $container->get('entity_type.manager')
-    );
+    // Instantiates this form class.
+    $instance = parent::create($container);
+    $instance->ahjoService = $container->get('helfi_ahjo.ahjo_service');
+    $instance->entityTypeManager = $container->get('entity_type.manager');
+    return $instance;
   }
 
   /**
@@ -204,7 +200,7 @@ class AhjoConfigForm extends ConfigFormBase {
       ->set('max_depth', $form_state->getValue('max_depth'))
 
       ->save();
-    $this->messenger->addStatus('Settings are updated!');
+    $this->messenger()->addStatus('Settings are updated!');
 
   }
 
@@ -216,7 +212,7 @@ class AhjoConfigForm extends ConfigFormBase {
       $data = $this->ahjoService->fetchDataFromRemote($form_state->getValue('org_id'), $form_state->getValue('max_depth'));
       if ($data) {
         $this->ahjoService->createTaxonomyBatch($data);
-        $this->messenger->addStatus('Sections imported and synchronized!');
+        $this->messenger()->addStatus('Sections imported and synchronized!');
       }
     }
     catch (\Exception $e) {

--- a/src/Form/AhjoConfigForm.php
+++ b/src/Form/AhjoConfigForm.php
@@ -3,38 +3,16 @@
 namespace Drupal\helfi_ahjo\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\helfi_ahjo\AhjoService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Gredi DAM module configuration form.
+ * AHJO organisation chart module configuration form.
  */
 class AhjoConfigForm extends ConfigFormBase {
-
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\helfi_ahjo\AhjoService
-   */
-  protected $ahjoService;
-
-  /**
-   * Messenger service.
-   *
-   * @var \Drupal\Core\Messenger\MessengerInterface
-   */
-  protected $messenger;
-
-  /**
-   * Logger factory service.
-   *
-   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
-   */
-  protected $loggerFactory;
 
   /**
    * Constructor.
@@ -43,20 +21,14 @@ class AhjoConfigForm extends ConfigFormBase {
    *   The factory for configuration objects.
    * @param \Drupal\helfi_ahjo\AhjoService $ahjoService
    *   Services for Ahjo API.
-   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
-   *   Service for messenger.
-   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerFactory
-   *   Service for logger factory.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   Entity type manager.
    */
   public function __construct(
-    ConfigFactoryInterface $config_factory,
-    AhjoService $ahjoService,
-    MessengerInterface $messenger,
-    LoggerChannelFactoryInterface $loggerFactory) {
+    protected ConfigFactoryInterface $config_factory,
+    protected AhjoService $ahjoService,
+    protected EntityTypeManagerInterface $entityTypeManager) {
     parent::__construct($config_factory);
-    $this->ahjoService = $ahjoService;
-    $this->messenger = $messenger;
-    $this->loggerFactory = $loggerFactory;
   }
 
   /**
@@ -66,8 +38,7 @@ class AhjoConfigForm extends ConfigFormBase {
     return new static(
       $container->get('config.factory'),
       $container->get('helfi_ahjo.ahjo_service'),
-      $container->get('messenger'),
-      $container->get('logger.factory')
+      $container->get('entity_type.manager')
     );
   }
 
@@ -259,7 +230,7 @@ class AhjoConfigForm extends ConfigFormBase {
    * Delete all imported data from sote section taxonomy.
    */
   public function deleteAllData(array &$form, FormStateInterface $form_state) {
-    $terms = \Drupal::entityTypeManager()
+    $terms = $this->entityTypeManager
       ->getStorage('taxonomy_term')
       ->loadByProperties(['vid' => 'sote_section']);
     $operations = [];

--- a/src/Utils/TaxonomyUtils.php
+++ b/src/Utils/TaxonomyUtils.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\helfi_ahjo\Utils;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 
 /**
@@ -10,20 +11,17 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 class TaxonomyUtils {
 
   /**
-   * Entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
    * TaxonomyUtils constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   Entity type manager.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config
+   *   Config factory.
    */
-  public function __construct(EntityTypeManagerInterface $entityTypeManager) {
-    $this->entityTypeManager = $entityTypeManager;
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected ConfigFactoryInterface $config,
+  ) {
   }
 
   /**
@@ -61,7 +59,7 @@ class TaxonomyUtils {
 
     foreach ($children as $child) {
       foreach ($child_tree_objects as $child_tree_object) {
-        if ($child_tree_object->tid == $child->id()) {
+        if ($child_tree_object->tid === $child->id()) {
           $this->buildTree($object_children, $child_tree_object, $vocabulary, $key, $depth);
           $key++;
         }
@@ -124,12 +122,13 @@ class TaxonomyUtils {
     $child_tree_objects = $this->entityTypeManager->getStorage('taxonomy_term')->loadTree($vocabulary, $object->tid);
 
     $depth++;
-    if ($depth == \Drupal::service('helfi_ahjo.ahjo_service')->getConfig()->get('organigram_max_depth')) {
+    $max_depth = $this->config->get('helfi_ahjo.ahjo_service')->get('organigram_max_depth');
+    if ($max_depth && $depth >= $max_depth) {
       return;
     }
     foreach ($children as $child) {
       foreach ($child_tree_objects as $child_tree_object) {
-        if ($child_tree_object->tid == $child->id()) {
+        if ($child_tree_object->tid === $child->id()) {
           $key++;
           $this->buildJsTree($object_children, $child_tree_object, $vocabulary, $key, $depth);
         }


### PR DESCRIPTION
# [UHF-9822](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9822)

D10 compatibility fixes and minor coding quality improvements.

## To install:
* If you're using the Demo site testing branch, you can ignore these steps
* Use composer to download this module on this specific branch:
   * `composer require drupal/helfi_ahjo:dev-drupal-10-compatibility`
* Make sure the module installs correctly: `drush en helfi_ahjo`

## To test:
* [x] Check that the module can be configured from: `/admin/config/ahjo` (ask Juho for the correct API keys and URLs)
  * Add 00001 or 02900 as the starting ID and 4 as the depth (9999 will take a really long time and might cause timeouts).  
* [x] Run the taxonomy term sync from the config form and make sure the terms are created correctly: /admin/structure/taxonomy/manage/sote_section/overview
  * [ ] Try getting more terms by changing the starting ID to 00400 and the depth to 3, if it crashes try running it again before lowering the depth to 2. 
* [x] Add the org chart paragraph to a page to check that it works
* [x] Run `drush cex` to make sure the API key is not exported.
  * Try changing the API key setting and running `drush cim`, the API key should stay the same.
* [x] Check that the code changes follow our standards

## Other PRs
* https://github.com/City-of-Helsinki/drupal-helfi-platform-test/pull/44

[UHF-9822]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ